### PR TITLE
Check if the exec function exists.

### DIFF
--- a/wp-db-backup.php
+++ b/wp-db-backup.php
@@ -1047,7 +1047,7 @@ class wpdbBackup {
 			/**
 			 * Try gzipping with an external application
 			 */
-			if ( file_exists( $diskfile ) && ! file_exists( $gz_diskfile ) ) {
+			if (function_exists('exec') && file_exists( $diskfile ) && ! file_exists( $gz_diskfile ) ) {
 				@exec( "gzip $diskfile" );
 			}
 


### PR DESCRIPTION
On the CentOS 7 server, it simply didn't go through this. After this check it moved to the other compression method and the backup was successfull.